### PR TITLE
Fix a bug where non-existent dir breaks rehash

### DIFF
--- a/etc/rbenv.d/rehash/bundler.bash
+++ b/etc/rbenv.d/rehash/bundler.bash
@@ -66,7 +66,7 @@ if [[ "${BASH_SOURCE[0]}" != "${BASH_SOURCE[1]}" ]]; then
     for cached_dir in "${cached_dirs[@]}"; do
 
         if [[ ! -d "$cached_dir" ]]; then
-            return
+            continue
         fi
 
         unset -- CACHED_DIR_OK


### PR DESCRIPTION
When iterating over cached bundle installation paths, if we encounter a path that no longer exists, skip over it rather than aborting the rehash script. Otherwise some paths will not be processed, and shims will not get created.
