### PR TITLE
Support BUNDLE_PATH being defined via $HOME/.bundle/config

### DIFF
--- a/etc/rbenv.d/rehash/bundler.bash
+++ b/etc/rbenv.d/rehash/bundler.bash
@@ -90,7 +90,7 @@ else
 
     cd -- "$SHIM_PATH" \
         && shopt -s -- nullglob \
-        && make_shims "$bundle_path"/ruby/*/bin/* \
+        && make_shims "$bundle_path"/ruby/*/bin/* "$bundle_path"/bin/* \
         ; shopt -u -- nullglob \
         ; cd -- "$RBENV_DIR"
 


### PR DESCRIPTION
Bundler allows `BUNDLE_PATH` to be defined in `$HOME/.bundle/config`. If defined in this manner, the working directory's version of `.bundle/config` will lack the `BUNDLE_PATH` setting. These commits modify rbenv-bundler to take this alternative configuration into account.
