### PR TITLE
Remove Gem.refresh when using to bundler-1.4 later

### DIFF
--- a/etc/rbenv.d/bundler/rehash.rb
+++ b/etc/rbenv.d/bundler/rehash.rb
@@ -90,7 +90,7 @@ module RbenvBundler
     end
 
     Bundler.rubygems.clear_paths
-    Bundler.rubygems.refresh
+    Bundler.rubygems.refresh if Bundler.rubygems.respond_to? :refresh
 
     runtime = Bundler::Runtime.new(bundler_gemfile.parent,
                                    Bundler::Definition.build(bundler_gemfile, bundler_lockfile, nil))
@@ -129,7 +129,7 @@ module RbenvBundler
       ENV.update(env_old)
 
       Bundler.rubygems.clear_paths
-      Bundler.rubygems.refresh
+      Bundler.rubygems.refresh if Bundler.rubygems.respond_to? :refresh
     end
   end
 


### PR DESCRIPTION
bundler-1.4.rc1 or later removed Bundler.rubygems.refresh. When we used bundler-1.4.rc1 with master of rbenv-bundler, rbenv-bundler rehash is failed by calling Bundler.rubygems.refresh.

PS. I don't understand that Bundler removed this method. ref https://github.com/bundler/bundler/commit/90611d4a8625884f0099d103e4e6cd2e1c5438c0 .
