### PR TITLE
 fix OpenStruct disallowed error in rehash.rb

### DIFF
--- a/etc/rbenv.d/bundler/rehash.rb
+++ b/etc/rbenv.d/bundler/rehash.rb
@@ -99,7 +99,7 @@ module RbenvBundler
 
       if !pid.nil?
         child_out.close
-        gemspecs = YAML.load(child_in) || []
+        gemspecs = YAML.load(child_in, permitted_classes: [OpenStruct]) || []
         child_in.close
 
         _, status = Process.waitpid2(pid)


### PR DESCRIPTION
fix  OpenStruct disallowed class in rehash.rb

A very noisy error that includes "**Tried to load unspecified class: OpenStruct (Psych::DisallowedClass)**" in Ruby 3.1.2 because OpenStruct is no longer allowed by default in YAML.load().

There may be a better way. But this does quiet things.