### PR TITLE
Permit extra classes in ruby profile YAML dumps

### DIFF
--- a/etc/rbenv.d/bundler/rehash.rb
+++ b/etc/rbenv.d/bundler/rehash.rb
@@ -262,7 +262,7 @@ module RbenvBundler
 
     if ruby_profiles_file.file?
       ruby_profile_map = ruby_profiles_file.open("rb") do |f|
-        YAML.load(f)
+        YAML.load(f, permitted_classes: [OpenStruct, Pathname])
       end
     else
       ruby_profile_map = {}


### PR DESCRIPTION
This is something I change to fix things each time I setup a new machine. Figured I'd open a pull request to see if you want to merge it.

Fixes:

/home/miles/.rbenv/versions/3.2.2/lib/ruby/3.2.0/psych/class_loader.rb:99:in `find': Tried to load unspecified class: OpenStruct (Psych::DisallowedClass)

I actually see the same fix in: https://github.com/carsomyr/rbenv-bundler/issues/57

Looks like there's a desire to perform a larger refactor to fix this mentioned in that issue conversation. I suppose that would involve not marshaling instances of these classes in the first place. But figured I'd open this to force considering committing to this stop-gap in the interim.